### PR TITLE
Add missed functions of libgio in system.gyp

### DIFF
--- a/src/build/linux/system.gyp
+++ b/src/build/linux/system.gyp
@@ -28,6 +28,8 @@
       'brlapi__readKey',
     ],
     'libgio_functions': [
+      'glib_check_version',
+      'g_type_init',
       'g_settings_new',
       'g_settings_get_child',
       'g_settings_get_string',


### PR DESCRIPTION
Without this, it causes the following build error on Linux.
````
../../net/proxy/proxy_config_service_linux.cc:819:24: error: no member named 'glib_check_version' in 'LibGioLoader'
    if (libgio_loader_.glib_check_version(2, 35, 0)) {
        ~~~~~~~~~~~~~~ ^
../../net/proxy/proxy_config_service_linux.cc:820:22: error: no member named 'g_type_init' in 'LibGioLoader'
      libgio_loader_.g_type_init();
      ~~~~~~~~~~~~~~ ^
````