### PR TITLE
Modify proto_quic_tools/sync.sh to fail if CHROME_ROOT or PROTO_QUIC_…

### DIFF
--- a/proto_quic_tools/sync.sh
+++ b/proto_quic_tools/sync.sh
@@ -5,6 +5,16 @@ if [ "$PROTO_QUIC_ROOT" == "" ]; then
     exit 1
 fi
 
+if [ ! -f "$PROTO_QUIC_ROOT/net/BUILD.gn" ]; then
+   echo "PROTO_QUIC_ROOT not set correctly"
+   exit 1
+fi
+
+if [ ! -f "$CHROME_ROOT/net/BUILD.gn" ]; then
+   echo "CHROME_ROOT not set correctly"
+   exit 1
+fi
+
 echo "_____ running src/third_party/binutils/download.py"
 $PROTO_QUIC_ROOT/third_party/binutils/download.py
 echo "_____ running /usr/bin/python src/build/linux/sysroot_scripts/install-sysroot.py --running-as-hook"


### PR DESCRIPTION
…ROOT are not set correctly.