### PR TITLE
new version of ninja required for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Building on Linux
 
 0. Clone this repository:
    ```
+   cd ~
    git clone https://github.com/google/proto-quic.git
+   git clone https://github.com/martine/ninja.git -b v1.7.2
+   cd ninja && ./configure.py --bootstrap
+   export PATH=$PATH:~/ninja/
+
    cd proto-quic
    export PROTO_QUIC_ROOT=`pwd`/src
    export PATH=$PATH:`pwd`/depot_tools

--- a/proto_quic_tools/sync.sh
+++ b/proto_quic_tools/sync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+export PROTO_QUIC_ROOT=`pwd`/src
 
 if [ "$PROTO_QUIC_ROOT" == "" ]; then
     echo "PROTO_QUIC_ROOT is not set"


### PR DESCRIPTION
As i was trying to build quic_client and source i encountered a problem with the ninja build version. I used the following steps to build it.
Also, the PROTO_QUIC_ROOT was not being changed for /proto-quic/proto_quic_tools/sync.sh, i also included the export statement in there.